### PR TITLE
print exenv version

### DIFF
--- a/libexec/exenv
+++ b/libexec/exenv
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
+
+if [ "$1" = "--debug" ]; then
+  export EXENV_DEBUG=1
+  shift
+fi
+
 [ -n "$EXENV_DEBUG" ] && set -x
 
 resolve_link() {

--- a/libexec/exenv
+++ b/libexec/exenv
@@ -66,7 +66,10 @@ shopt -u nullglob
 command="$1"
 case "$command" in
 "" | "-h" | "--help" )
-  echo -e "exenv 0.1.0\n$(exenv-help)" >&2
+  echo -e "$(exenv---version)\n$(exenv-help)" >&2
+  ;;
+"-v" )
+  exec exenv---version
   ;;
 * )
   command_path="$(command -v "exenv-$command" || true)"

--- a/libexec/exenv---version
+++ b/libexec/exenv---version
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Summary: Display the version of exenv
+#
+# Displays the version number of this exenv release, including the
+# current revision from git, if available.
+#
+# The format of the git revision is:
+#   <version>-<num_commits>-<git_sha>
+# where `num_commits` is the number of commits since `version` was
+# tagged.
+
+set -e
+[ -n "$EXENV_DEBUG" ] && set -x
+
+version="0.1.0"
+
+if cd "$EXENV_ROOT" 2>/dev/null; then
+  git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
+  git_revision="${git_revision#v}"
+fi
+
+echo "exenv ${git_revision:-$version}"


### PR DESCRIPTION
Print the exenv version when requested with `-v` or `--version`.

``` sh
$ exenv --version
exenv 0.1.0
$ exenv -v
exenv 0.1.0
```

When running from a git repo install:

``` sh
$ exenv --version
exenv 0.1.0-8-g0013bb6
```

Also support `--debug`.

(as rbenv does it)
