### PR TITLE
fix documentation link in command line help

### DIFF
--- a/libexec/exenv-help
+++ b/libexec/exenv-help
@@ -31,7 +31,7 @@ Some useful exenv commands are:
    which         Show the full path for the given Elixir command
 
 See 'exenv help <command>' for information on a specific command.
-For full documentation, see: https://github.com/sstephenson/exenv#readme"
+For full documentation, see: https://github.com/mururu/exenv#readme"
 ;;
 commands) echo "usage: exenv commands
        exenv commands --sh


### PR DESCRIPTION
I just noticed you got a little bit too inspired by `rbenv` and are linking to `sstephenson` instead of yourself :)
