### PR TITLE
added context for error in exenv-version-name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/plugins/*
 !/plugins/.keep
 /shims
 /version

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/plugins
+!/plugins/.keep
 /shims
 /version
 /versions

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Sam Stephenson, Yuki Ito
+(The MIT license)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ easy to fork and contribute any changes back upstream.
 1. Check out exenv into `~/.exenv`.
 
         $ cd
-        $ git clone git://github.com/mururu/exenv.git .exenv
+        $ git clone git://github.com/jtzero/exenv.git .exenv
 
 2. Add `~/.exenv/bin` to your `$PATH` for access to the `exenv`
    command-line utility.
@@ -247,14 +247,21 @@ Using [elixir-build](https://github.com/mururu/elixir-build),
 you can install Elixir automatically. Please see here([elixir-build](https://github.com/mururu/elixir-build))
 for more details.
 
+### <a name="section_3.9"></a> 3.9 exenv install-erlang
+
+Elixir needs erlang to run.
+Using [erlang-build](https://github.com/jtzero/erlang-build),
+you can install Erlang automatically. Please see here([elixir-build](https://github.com/jtzero/erlang-build))
+for more details.
+
 ## <a name="section_4"></a> 4 Development
 
 The exenv source code is [hosted on
-GitHub](https://github.com/mururu/exenv). It's clean, modular,
+GitHub](https://github.com/jtzero/exenv). It's clean, modular,
 and easy to understand, even if you're not a shell hacker.
 
 Please feel free to submit pull requests and file bugs on the [issue
-tracker](https://github.com/mururu/exenv/issues).
+tracker](https://github.com/jtzero/exenv/issues).
 
 ### <a name="section_4.1"></a> 4.1 Version History
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ easy to fork and contribute any changes back upstream.
         $ wget https://github.com/elixir-lang/elixir/archive/v0.13.3.zip
         $ unzip v0.13.3.zip
         $ mv elixir-0.13.3/ ~/.exenv/versions/0.13.3
+        $ cd ~/.exenv/versions/0.13.3
+        $ make
 
 6. Rebuild the shim binaries. You should do this any time you install
    a new Elixir binary (for example, when installing a new Elixir version,

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ tracker](https://github.com/jtzero/exenv/issues).
 ### <a name="section_4.1"></a> 4.1 Version History
 
 **0.1.0** (November 10, 2012)
+**0.2.0** (April 9, 2017)
 
 Fork [rbenv](https://github.com/sstephenson/rbenv)
 

--- a/README.md
+++ b/README.md
@@ -267,8 +267,6 @@ Fork [rbenv](https://github.com/sstephenson/rbenv)
 
 (The MIT license)
 
-Copyright (c) 2011 Sam Stephenson, Yuki Ito
-
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including

--- a/README.md
+++ b/README.md
@@ -266,23 +266,4 @@ Fork [rbenv](https://github.com/sstephenson/rbenv)
 
 ### <a name="section_4.2"></a> 4.2 License
 
-(The MIT license)
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Check [LICENSE](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ first argument. The most common subcommands are:
 
 Sets the global version of Elixir to be used in all shells by writing
 the version name to the `~/.exenv/version` file. This version can be
-overridden by a per-project `.exenv-version` file, or by setting the
+overridden by a per-project `.elixir-version` file, or by setting the
 `EXENV_VERSION` environment variable.
 
     $ exenv global 0.7.0
@@ -173,7 +173,7 @@ currently configured global version.
 ### <a name="section_3.2"></a> 3.2 exenv local
 
 Sets a local per-project Elixir version by writing the version name to
-an `.exenv-version` file in the current directory. This version
+an `.elixir-version` file in the current directory. This version
 overrides the global, and can be overridden itself by setting the
 `EXENV_VERSION` environment variable or with the `exenv shell`
 command.
@@ -221,7 +221,7 @@ Displays the currently active Elixir version, along with information on
 how it was set.
 
     $ exenv version
-    0.7.0 (set by /Volumes/37signals/basecamp/.exenv-version)
+    0.7.0 (set by /Volumes/37signals/basecamp/.elixir-version)
 
 ### <a name="section_3.6"></a> 3.6 exenv rehash
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Thanks to @sstephenson and @repeatedly.
       * [3.5 exenv version](#section_3.5)
       * [3.6 exenv rehash](#section_3.6)
       * [3.7 exenv which](#section_3.7)
+      * [3.8 exenv install](#section_3.8)
    * [4 Development](#section_4)
       * [4.1 Version History](#section_4.1)
       * [4.2 License](#section_4.2)
@@ -245,13 +246,6 @@ run the given command.
 
 Using [elixir-build](https://github.com/mururu/elixir-build),
 you can install Elixir automatically. Please see here([elixir-build](https://github.com/mururu/elixir-build))
-for more details.
-
-### <a name="section_3.9"></a> 3.9 exenv install-erlang
-
-Elixir needs erlang to run.
-Using [erlang-build](https://github.com/jtzero/erlang-build),
-you can install Erlang automatically. Please see here([elixir-build](https://github.com/jtzero/erlang-build))
 for more details.
 
 ## <a name="section_4"></a> 4 Development

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+no longer maintained use https://github.com/asdf-vm/asdf-elixir
+
 # Simple Elixir Version Management: exenv
 
 exenv lets you easily switch between multiple versions of Elixir. It's

--- a/bin/elixir-local-exec
+++ b/bin/elixir-local-exec
@@ -5,7 +5,7 @@
 #
 #    #!/usr/bin/env elixir-local-exec
 #
-# Use it for scripts inside a project with an `.exenv-version`
+# Use it for scripts inside a project with an `.elixir-version`
 # file. When you run the scripts, they'll use the project-specified
 # Elixir version, regardless of what directory they're run from. Useful
 # for e.g. running project tasks in cron scripts without needing to

--- a/completions/exenv.fish
+++ b/completions/exenv.fish
@@ -1,0 +1,22 @@
+function __fish_exenv_needs_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -eq 1 -a $cmd[1] = 'exenv' ]
+    return 0
+  end
+  return 1
+end
+
+function __fish_exenv_using_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -gt 1 ]
+    if [ $argv[1] = $cmd[2] ]
+      return 0
+    end
+  end
+  return 1
+end
+
+complete -f -c exenv -n '__fish_exenv_needs_command' -a '(exenv commands)'
+for cmd in (exenv commands)
+  complete -f -c exenv -n "__fish_exenv_using_command $cmd" -a "(exenv completions $cmd)"
+end

--- a/libexec/exenv
+++ b/libexec/exenv
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -e
+
+if [ "$1" = "--debug" ]; then
+  export EXENV_DEBUG=1
+  shift
+fi
+
 [ -n "$EXENV_DEBUG" ] && set -x
 
 resolve_link() {
@@ -60,7 +66,10 @@ shopt -u nullglob
 command="$1"
 case "$command" in
 "" | "-h" | "--help" )
-  echo -e "exenv 0.1.0\n$(exenv-help)" >&2
+  echo -e "$(exenv---version)\n$(exenv-help)" >&2
+  ;;
+"-v" )
+  exec exenv---version
   ;;
 * )
   command_path="$(command -v "exenv-$command" || true)"

--- a/libexec/exenv---version
+++ b/libexec/exenv---version
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Summary: Display the version of exenv
+#
+# Displays the version number of this exenv release, including the
+# current revision from git, if available.
+#
+# The format of the git revision is:
+#   <version>-<num_commits>-<git_sha>
+# where `num_commits` is the number of commits since `version` was
+# tagged.
+
+set -e
+[ -n "$EXENV_DEBUG" ] && set -x
+
+version="0.1.0"
+
+if cd "$EXENV_ROOT" 2>/dev/null; then
+  git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
+  git_revision="${git_revision#v}"
+fi
+
+echo "exenv ${git_revision:-$version}"

--- a/libexec/exenv-help
+++ b/libexec/exenv-help
@@ -51,9 +51,9 @@ local) echo "usage: exenv local <version>
        exenv local --unset
 
 Sets the local directory-specific Elixir version by writing the version
-name to a file named '.exenv-version'.
+name to a file named '.elixir-version'.
 
-When you run a Elixir command, exenv will look for an '.exenv-version'
+When you run a Elixir command, exenv will look for an '.elixir-version'
 file in the current directory and each parent directory. If no such
 file is found in the tree, exenv will use the global Elixir version
 specified with \`exenv global', or the version specified in the

--- a/libexec/exenv-help
+++ b/libexec/exenv-help
@@ -31,7 +31,7 @@ Some useful exenv commands are:
    which         Show the full path for the given Elixir command
 
 See 'exenv help <command>' for information on a specific command.
-For full documentation, see: https://github.com/sstephenson/exenv#readme"
+For full documentation, see: https://github.com/jtzero/exenv#readme"
 ;;
 commands) echo "usage: exenv commands
        exenv commands --sh

--- a/libexec/exenv-init
+++ b/libexec/exenv-init
@@ -17,7 +17,7 @@ do
   fi
 done
 
-shell="$1"
+
 if [ -z "$shell" ]; then
   shell="$(basename "$SHELL")"
 fi
@@ -53,6 +53,9 @@ if [ -z "$print" ]; then
   ksh )
     profile='~/.profile'
     ;;
+  fish )
+    profile='~/.config/fish/config.fish'
+    ;;
   * )
     profile='your profile'
     ;;
@@ -61,7 +64,14 @@ if [ -z "$print" ]; then
   { echo "# Load exenv automatically by adding"
     echo "# the following to ${profile}:"
     echo
-    echo 'eval "$(exenv init -)"'
+    case "$shell" in
+    fish )
+      echo 'status --is-interactive; and . (exenv init -|psub)'
+      ;;
+    * )
+      echo 'eval "$(exenv init -)"'
+      ;;
+    esac
     echo
   } >&2
 
@@ -70,10 +80,13 @@ fi
 
 mkdir -p "${EXENV_ROOT}/"{shims,versions}
 
-echo 'export PATH="'${EXENV_ROOT}'/shims:${PATH}"'
-
 case "$shell" in
+fish )
+  echo "setenv PATH '${EXENV_ROOT}/shims' \$PATH"
+  echo ". \"$root/completions/exenv.${shell}\""
+  ;;
 bash | zsh )
+  echo 'export PATH="'${EXENV_ROOT}'/shims:${PATH}"'
   echo "source \"$root/completions/exenv.${shell}\""
   ;;
 esac
@@ -83,6 +96,27 @@ if [ -z "$no_rehash" ]; then
 fi
 
 commands=(`exenv commands --sh`)
+case "$shell" in
+fish )
+  cat <<EOS
+function exenv
+  set command \$argv[1]
+  set -e argv[1]
+
+  switch "\$command"
+  case ${commands[*]}
+    eval (exenv "sh-\$command" \$argv)
+  case '*'
+    command exenv "\$command" \$argv
+  end
+end
+EOS
+  ;;
+* )
+  ;;
+esac
+
+if [ "$shell" != "fish" ]; then
 IFS="|"
 cat <<EOS
 exenv() {
@@ -99,3 +133,4 @@ exenv() {
   esac
 }
 EOS
+fi

--- a/libexec/exenv-init
+++ b/libexec/exenv-init
@@ -91,6 +91,13 @@ bash | zsh )
   ;;
 esac
 
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`exenv-hooks init`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  echo "source \"$script\""
+done
+
 if [ -z "$no_rehash" ]; then
   echo 'exenv rehash 2>/dev/null'
 fi

--- a/libexec/exenv-local
+++ b/libexec/exenv-local
@@ -10,14 +10,19 @@ if [ "$1" = "--complete" ]; then
 fi
 
 EXENV_VERSION="$1"
-EXENV_VERSION_FILE=".exenv-version"
+EXENV_VERSION_FILE=".elixir-version"
+OLD_EXENV_VERSION_FILE=".exenv-version"
 
 if [ "$EXENV_VERSION" = "--unset" ]; then
   rm -f "$EXENV_VERSION_FILE"
 elif [ -n "$EXENV_VERSION" ]; then
   exenv-version-file-write "$EXENV_VERSION_FILE" "$EXENV_VERSION"
+elif [ -e "$EXENV_VERSION_FILE" ]; then
+  exenv-version-file-read "$EXENV_VERSION_FILE"
+elif [ -e "$OLD_EXENV_VERSION_FILE" ]; then
+  echo "exenv: Use of the .exenv-version file is deprecated. Rename to .elixir-version"
+  exenv-version-file-read "$OLD_EXENV_VERSION_FILE"
 else
-  exenv-version-file-read "$EXENV_VERSION_FILE" ||
   { echo "exenv: no local version configured for this directory"
     exit 1
   } >&2

--- a/libexec/exenv-version
+++ b/libexec/exenv-version
@@ -2,4 +2,4 @@
 set -e
 [ -n "$EXENV_DEBUG" ] && set -x
 
-echo "$(exenv-version-name) (set by $(exenv-version-origin))"
+echo "$(exenv-version-name) $(exenv-version-origin-message)"

--- a/libexec/exenv-version-file
+++ b/libexec/exenv-version-file
@@ -4,7 +4,11 @@ set -e
 
 root="$EXENV_DIR"
 while [ -n "$root" ]; do
-  if [ -e "${root}/.exenv-version" ]; then
+  if [ -e "${root}/.elixir-version" ]; then
+    echo "${root}/.elixir-version"
+    exit
+  elif [ -e "${root}/.exenv-version" ]; then
+    echo "exenv: Use of the .exenv-version file is deprecated. Rename to .elixir-version"
     echo "${root}/.exenv-version"
     exit
   fi

--- a/libexec/exenv-version-name
+++ b/libexec/exenv-version-name
@@ -7,16 +7,28 @@ if [ -z "$EXENV_VERSION" ]; then
   EXENV_VERSION="$(exenv-version-file-read "$EXENV_VERSION_FILE" || true)"
 fi
 
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`exenv-hooks version-name`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  source "$script"
+done
+
 if [ -z "$EXENV_VERSION" ] || [ "$EXENV_VERSION" = "system" ]; then
   echo "system"
   exit
 fi
 
-EXENV_VERSION_PATH="${EXENV_ROOT}/versions/${EXENV_VERSION}"
+version_exists() {
+  local version="$1"
+  [ -d "${EXENV_ROOT}/versions/${version}" ]
+}
 
-if [ -d "$EXENV_VERSION_PATH" ]; then
+if version_exists "$EXENV_VERSION"; then
   echo "$EXENV_VERSION"
+elif version_exists "${EXENV_VERSION#ruby-}"; then
+  echo "${EXENV_VERSION#ruby-}"
 else
-  echo "exenv: version \`$EXENV_VERSION' $(exenv-version-origin-message) is not installed" >&2
+  echo "exenv: version \`$EXENV_VERSION' is not installed (set by $(exenv-version-origin))" >&2
   exit 1
 fi

--- a/libexec/exenv-version-name
+++ b/libexec/exenv-version-name
@@ -17,6 +17,6 @@ EXENV_VERSION_PATH="${EXENV_ROOT}/versions/${EXENV_VERSION}"
 if [ -d "$EXENV_VERSION_PATH" ]; then
   echo "$EXENV_VERSION"
 else
-  echo "exenv: version \`$EXENV_VERSION' is not installed" >&2
+  echo "exenv: version \`$EXENV_VERSION' $(exenv-version-origin-message) is not installed" >&2
   exit 1
 fi

--- a/libexec/exenv-version-origin-message
+++ b/libexec/exenv-version-origin-message
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$EXENV_DEBUG" ] && set -x
+
+echo "(set by $(exenv-version-origin))"


### PR DESCRIPTION
Added the origin to "is not installed" -> `exenv: version `a1.2.2' (set by /home/jtzero/.exenv-version) is not installed`

Created `exenv-version-origin-message` to keep the origin message the same across both `exenv-version-name` and `exenv-version`
