### PR TITLE
use elixir-version instead of exenv-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ first argument. The most common subcommands are:
 
 Sets the global version of Elixir to be used in all shells by writing
 the version name to the `~/.exenv/version` file. This version can be
-overridden by a per-project `.exenv-version` file, or by setting the
+overridden by a per-project `.elixir-version` file, or by setting the
 `EXENV_VERSION` environment variable.
 
     $ exenv global 0.7.0
@@ -173,7 +173,7 @@ currently configured global version.
 ### <a name="section_3.2"></a> 3.2 exenv local
 
 Sets a local per-project Elixir version by writing the version name to
-an `.exenv-version` file in the current directory. This version
+an `.elixir-version` file in the current directory. This version
 overrides the global, and can be overridden itself by setting the
 `EXENV_VERSION` environment variable or with the `exenv shell`
 command.
@@ -221,7 +221,7 @@ Displays the currently active Elixir version, along with information on
 how it was set.
 
     $ exenv version
-    0.7.0 (set by /Volumes/37signals/basecamp/.exenv-version)
+    0.7.0 (set by /Volumes/37signals/basecamp/.elixir-version)
 
 ### <a name="section_3.6"></a> 3.6 exenv rehash
 

--- a/bin/elixir-local-exec
+++ b/bin/elixir-local-exec
@@ -5,7 +5,7 @@
 #
 #    #!/usr/bin/env elixir-local-exec
 #
-# Use it for scripts inside a project with an `.exenv-version`
+# Use it for scripts inside a project with an `.elixir-version`
 # file. When you run the scripts, they'll use the project-specified
 # Elixir version, regardless of what directory they're run from. Useful
 # for e.g. running project tasks in cron scripts without needing to

--- a/libexec/exenv-help
+++ b/libexec/exenv-help
@@ -51,9 +51,9 @@ local) echo "usage: exenv local <version>
        exenv local --unset
 
 Sets the local directory-specific Elixir version by writing the version
-name to a file named '.exenv-version'.
+name to a file named '.elixir-version'.
 
-When you run a Elixir command, exenv will look for an '.exenv-version'
+When you run a Elixir command, exenv will look for an '.elixir-version'
 file in the current directory and each parent directory. If no such
 file is found in the tree, exenv will use the global Elixir version
 specified with \`exenv global', or the version specified in the

--- a/libexec/exenv-local
+++ b/libexec/exenv-local
@@ -10,14 +10,19 @@ if [ "$1" = "--complete" ]; then
 fi
 
 EXENV_VERSION="$1"
-EXENV_VERSION_FILE=".exenv-version"
+EXENV_VERSION_FILE=".elixir-version"
+OLD_EXENV_VERSION_FILE=".exenv-version"
 
 if [ "$EXENV_VERSION" = "--unset" ]; then
   rm -f "$EXENV_VERSION_FILE"
 elif [ -n "$EXENV_VERSION" ]; then
   exenv-version-file-write "$EXENV_VERSION_FILE" "$EXENV_VERSION"
+elif [ -e "$EXENV_VERSION_FILE" ]; then
+  exenv-version-file-read "$EXENV_VERSION_FILE"
+elif [ -e "$OLD_EXENV_VERSION_FILE" ]; then
+  echo "exenv: Use of the .exenv-version file is deprecated. Rename to .elixir-version"
+  exenv-version-file-read "$OLD_EXENV_VERSION_FILE"
 else
-  exenv-version-file-read "$EXENV_VERSION_FILE" ||
   { echo "exenv: no local version configured for this directory"
     exit 1
   } >&2

--- a/libexec/exenv-version-file
+++ b/libexec/exenv-version-file
@@ -4,7 +4,11 @@ set -e
 
 root="$EXENV_DIR"
 while [ -n "$root" ]; do
-  if [ -e "${root}/.exenv-version" ]; then
+  if [ -e "${root}/.elixir-version" ]; then
+    echo "${root}/.elixir-version"
+    exit
+  elif [ -e "${root}/.exenv-version" ]; then
+    echo "exenv: Use of the .exenv-version file is deprecated. Rename to .elixir-version"
     echo "${root}/.exenv-version"
     exit
   fi


### PR DESCRIPTION
@mururu 

This was brought up in https://github.com/mururu/exenv/issues/3

Most version managers like `rbenv` and `nodenv` use a version file with the format `.{language}-version`.  I think it would be nice and more consistent if this switched to `.elixir-version`.  

This will still read from `.exenv-version` files, but print a deprecation message.  